### PR TITLE
Chart update improvements

### DIFF
--- a/gui/js/barterdexcharts.js
+++ b/gui/js/barterdexcharts.js
@@ -269,8 +269,6 @@ function parseBars(data, isIntraday) {
     gChart.updateComputedDataSeries();
     gChart.update();
     gChart.hideWaitingBar();
-
-    console.log('ELEMENTS', gChart.barDataSeries().date.values.length);
 }
 
 

--- a/gui/js/barterdexcharts.js
+++ b/gui/js/barterdexcharts.js
@@ -227,12 +227,28 @@ function parseBars(data, isIntraday) {
     //data.reverse();
     gChart.showWaitingBar();
     var newBars = [];
+    var entryExists;
     $.each(data, function (index, value) {
+    	entryExists = false;
         var time = new Date(value[0] * 1000);
 
-        if (dataSeries.date.values.length < index) {
-            // if the data received from the API call contains more bars than the chart currently has
-            // those bars should be appended to the chart
+        for (var i = 0; i < dataSeries.date.values.length; i++) {
+        	if (time.getTime() === dataSeries.date.values[i].getTime()) {
+                // if the bar already exists, just update the data
+                dataSeries.open.values[index] = parseFloat(value[1]);
+                dataSeries.high.values[index] = parseFloat(value[2]);
+                dataSeries.low.values[index] = parseFloat(value[3]);
+                dataSeries.close.values[index] = parseFloat(value[4]);
+                dataSeries.volume.values[index] = parseInt(value[5], 10);
+                entryExists = true;
+                break;
+			} else if (time > dataSeries.date.values[i]) {
+        		// since the dates in dataSeries are sorted, if 'time' is after the currently looped date, it surely doesn't exist yet
+        		break;
+			}
+		}
+
+		if (!entryExists) {
             var newBar = {
                 'date': time,
                 'open': parseFloat(value[1]),
@@ -242,14 +258,6 @@ function parseBars(data, isIntraday) {
                 'volume': parseInt(value[5], 10),
             };
             newBars.push(newBar);
-        } else {
-            // if the bar already exists, just update the data
-            dataSeries.date.values[index] = time;
-            dataSeries.open.values[index] = parseFloat(value[1]);
-            dataSeries.high.values[index] = parseFloat(value[2]);
-            dataSeries.low.values[index] = parseFloat(value[3]);
-            dataSeries.close.values[index] = parseFloat(value[4]);
-            dataSeries.volume.values[index] = parseInt(value[5], 10);
         }
     });
 
@@ -261,6 +269,8 @@ function parseBars(data, isIntraday) {
     gChart.updateComputedDataSeries();
     gChart.update();
     gChart.hideWaitingBar();
+
+    console.log('ELEMENTS', gChart.barDataSeries().date.values.length);
 }
 
 

--- a/gui/js/electrum_list.js
+++ b/gui/js/electrum_list.js
@@ -4,7 +4,7 @@ var electrum_servers_list = {
   "BCH": [{"electrum2.cipig.net":10051},{"electrum1.cipig.net":10051}],
   "BTC": [{"electrum2.cipig.net":10000},{"electrum1.cipig.net":10000}],
   "BOTS": [{"electrum2.cipig.net":10007},{"electrum1.cipig.net":10007}],
-  "CHIPS": [{"173.212.225.176": 50076},{"136.243.45.140": 50076}],
+  "CHIPS": [{"electrum2.cipig.net":10053},{"electrum1.cipig.net":10053}],
   "COQUI": [{"electrum2.cipig.net":10011},{"electrum1.cipig.net":10011}],
   "CRW": [{"173.212.225.176": 50041},{"136.243.45.140": 50041}],
   "CRYPTO": [{"electrum2.cipig.net":10008},{"electrum1.cipig.net":10008}],


### PR DESCRIPTION
When the data is being updated, the entries are now compared based on their timestamp instead of their array index. This will allow for more historical data to be displayed. Up until now, only the last 1025 entries (that amount of entries that each API call returns) were being displayed.

@satindergrewal take a look when you can