### PR TITLE
Increase chart default time interval; detect theme changes

### DIFF
--- a/gui/js/barterdexcharts.js
+++ b/gui/js/barterdexcharts.js
@@ -24,7 +24,8 @@ $(function() {
     gChart = $('#chartContainer').StockChartX({
         width: $('#chartContainer').parent().width(),
         height: 360,
-		theme: chartTheme
+		theme: chartTheme,
+        timeInterval: 1000 * 60
         //fullWindowMode: isFullWindowMode
     });
 
@@ -99,7 +100,7 @@ function ChartsInstruments(instrument_data){
 		company: instrument_data.company,
 		exchange: "BarterDEX"
 	};
-	gChart.timeInterval = StockChartX.TimeSpan.MILLISECONDS_IN_DAY;
+	// gChart.timeInterval = StockChartX.TimeSpan.MILLISECONDS_IN_DAY;
 	gChart.removeDrawings();
 	gChart.setNeedsUpdate(!0);
 	gChart.setNeedsAutoScaleAll();
@@ -274,4 +275,13 @@ function Refresh_active_StockChart(sig) {
 		console.log('Refreshing active StockCharts every minute.');
 	}
 	UpdateDexChart($('.trading_pair_coin2').selectpicker('val'),$('.trading_pair_coin').selectpicker('val'));
+}
+
+function RefreshStockChartTheme(selectedTheme) {
+    var chartTheme = StockChartX.Theme.Light;
+    if (selectedTheme === "dark") {
+        chartTheme = StockChartX.Theme.Dark;
+    }
+    gChart.theme = chartTheme;
+    gChart.update();
 }

--- a/gui/js/ipc-actions.js
+++ b/gui/js/ipc-actions.js
@@ -387,7 +387,8 @@ $('.dexsettings-btn').click(function(e){
 					console.log(barterDEX_settings);
 					ShepherdIPC({"command":"update_settings", "data":barterDEX_settings});
 					BarterDEXSettingsFn();
-					if (barterDEX_settings.deflang == 'tlh_UNI') {
+                    RefreshStockChartTheme(selected_theme);
+                    if (barterDEX_settings.deflang == 'tlh_UNI') {
 						$('body').css('font-family','piqad');
 						BarterDEXDefaultLangFn(selected_deflang);
 					} else {

--- a/gui/js/simpledexactions.js
+++ b/gui/js/simpledexactions.js
@@ -266,7 +266,7 @@ $('.porfolio_coins_list tbody').on('click', '.btn-portfoliogo', function() {
 
 	//getZeroConfDepositHistory();
 
-	sessionStorage.setItem('mm_chartinterval', JSON.stringify({"periodicity":"","interval":1}));
+	sessionStorage.setItem('mm_chartinterval', JSON.stringify({"periodicity":"h","interval":1}));
 
 	var charts_instruments_data = {}
 	if ($(this).data('coin') == 'KMD') {


### PR DESCRIPTION
1. Set the default time interval to 1h - this addresses https://github.com/KomodoPlatform/BarterDEX/issues/10

2. When the app theme is changed, the change is now reflected on the chart as well