### PR TITLE
bot_data undefined

### DIFF
--- a/gui/js/simpledexactions.js
+++ b/gui/js/simpledexactions.js
@@ -729,7 +729,7 @@ $('.btn-bot_action').click(function(e){
 
 		if (trading_options == 'disabled') {
 			if (trade_data.volume <= 0.01) {
-				console.log(bot_data.volume)
+				console.log(trade_data.volume)
 				console.log('Order is too small. Please try again.');
 				toastr.warning(`${default_lang.Exchange.exchange_toastr_order_is_too_small}`, `${default_lang.Exchange.exchange_toastr_order_title}`)
 			} else {


### PR DESCRIPTION
When checking to see if trade is too small, console log calls 'bot_data' instead of 'trade_data'. There is no 'bot_data' that exists at this point, so it throws an error.