### PR TITLE
Closes #67 

### DIFF
--- a/gui/css/custom.css
+++ b/gui/css/custom.css
@@ -157,6 +157,7 @@ textarea {
 
 .orderbook_asks tr:hover td, .orderbook_bids tr:hover td {
   background: #000;
+  color: #fff;
 }
 
 .progress-nomargin {


### PR DESCRIPTION
Minor css targeting bug when hovering on orderbook asks and bids in the light theme.