### PR TITLE
Returned a wandering div back into formation

### DIFF
--- a/gui/index.html
+++ b/gui/index.html
@@ -690,9 +690,10 @@
                                                             <div class="state p-success-o">
                                                                 <label class="language" data-langstr="exchange_enable_auto_repeat_coinmarketcap"></label>
                                                             </div>
-                                                        <button class="btn btn-xs exchange_enable_auto_repeat_coinmarketcap_info_btn"><i class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="top" title="info"></i></button>
-                                                    </div>
                                                         </div>
+                                                        <button class="btn btn-xs exchange_enable_auto_repeat_coinmarketcap_info_btn"><i class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="top" title="info"></i></button>
+                                                        <br>
+                                                    </div>
 
                                                 </div>
 


### PR DESCRIPTION
On exchange screen, trading options positioning was unaligned due to wandering tag drifting down to include tooltip button for "Enable auto-price market maker" mode block.
A `<br>` was added to match above blocks.