### PR TITLE
Update ReadMe.md

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -6,8 +6,8 @@ The BarterDEX application created by Komodo Platform allows trading cryptocurren
 -matching aspect uses a low-level pubkey-to-pubkey messaging protocol, and the final settlement is executed through an atomic cross-chain swap. 
 
 [Komodo Platform Official Site](https://komodoplatform.com)  
-[Komodo BarterDEX Page](https://komodoplatform.com/decentralized-exchange)  
-[Komodo Whitepaper](https://komodoplatform.com/wp-content/uploads/2018/03/2018-03-12-Komodo-White-Paper-Full.pdf)
+[Komodo BarterDEX Support Page](https://support.komodoplatform.com/support/solutions/29000034533)  
+[Komodo Whitepaper](https://komodoplatform.com/whitepaper)
 
 
 # BarterDEX App


### PR DESCRIPTION
The 2 links gave a 404 error. Changed the Whitepaper link to a more generic one that is redirected to the latest whitepaper. BarterDex currently doesn't have a page within komodoplatform.com, except the support page.